### PR TITLE
mat-select  does not enforce mode.required

### DIFF
--- a/packages/ui-material/src/dynamic-material-form-control.component.html
+++ b/packages/ui-material/src/dynamic-material-form-control.component.html
@@ -169,6 +169,7 @@
 
 
         <mat-select *ngSwitchCase="7" #matSelect
+                    [required]="model.required"
                     [dynamicId]="bindId && model.id"
                     [formControlName]="model.id"
                     [multiple]="model.multiple"


### PR DESCRIPTION
mat-select (Material Select) does not properly enforce the required attribute when provided.

just added the required attribute onto the mat-select directly as per https://material.angular.io/components/select/api