### PR TITLE
Adds maxLength attribute to the TextArea control in material-ui

### DIFF
--- a/packages/ui-material/src/dynamic-material-form-control.component.html
+++ b/packages/ui-material/src/dynamic-material-form-control.component.html
@@ -316,6 +316,7 @@
                       [formControlName]="model.id"
                       [id]="bindId ? model.id : null"
                       [minlength]="model.minLength"
+                      [maxlength]="model.maxLength"
                       [name]="model.name"
                       [ngClass]="getClass('element', 'control')"
                       [placeholder]="model.placeholder"


### PR DESCRIPTION
This PR adds the maxlength attribute to the TextArea control (case 11) for material-ui. Previously it was not functional.