### PR TITLE
#647: length error messages are not created

### DIFF
--- a/packages/core/src/service/dynamic-form-validation.service.spec.ts
+++ b/packages/core/src/service/dynamic-form-validation.service.spec.ts
@@ -162,9 +162,10 @@ describe("DynamicFormValidationService test suite", () => {
             testControl: FormControl = new FormControl(),
             testModel: DynamicFormControlModel = new DynamicInputModel({
                 id: "testModel",
+                minLength: 5,
                 errorMessages: {
                     required: "Field is required",
-                    minLength: 5,
+                    minLength: "Field must contain at least {{ minLength }} characters",
                     custom1: "Field {{ id }} has a custom error",
                     custom2: "Field has a custom error: {{ validator.param }}"
                 }
@@ -176,8 +177,9 @@ describe("DynamicFormValidationService test suite", () => {
         testControl.setErrors({required: true, minlength: 5});
 
         errorMessages = service.createErrorMessages(testControl, testModel);
-        expect(errorMessages.length).toBe(1);
+        expect(errorMessages.length).toBe(2);
         expect(errorMessages[0]).toEqual((testModel.errorMessages as any)["required"]);
+        expect(errorMessages[1]).toEqual("Field must contain at least 5 characters");
 
         testControl.setErrors({custom1: true});
 

--- a/packages/core/src/service/dynamic-form-validation.service.ts
+++ b/packages/core/src/service/dynamic-form-validation.service.ts
@@ -169,7 +169,7 @@ export class DynamicFormValidationService {
                 let messageKey = validationErrorKey;
 
                 if (validationErrorKey === "minlength" || validationErrorKey === "maxlength") {
-                    messageKey.replace("length", "Length");
+                    messageKey = messageKey.replace("length", "Length");
                 }
 
                 if (messagesConfig.hasOwnProperty(messageKey)) {


### PR DESCRIPTION
The replaced `messageKey` was not assigned.