### PR TITLE
feat(tooltips): add props for storing tooltip text

### DIFF
--- a/packages/core/src/model/dynamic-form-control.model.ts
+++ b/packages/core/src/model/dynamic-form-control.model.ts
@@ -14,6 +14,8 @@ export interface DynamicFormControlModelConfig {
     hidden?: boolean;
     id: string;
     label?: string;
+    labelTooltip?: string;
+    controlTooltip?: string;
     name?: string;
     relation?: DynamicFormControlRelationGroup[];
     updateOn?: FormHooks;
@@ -29,6 +31,8 @@ export abstract class DynamicFormControlModel implements DynamicPathable {
     @serializable() hidden: boolean;
     @serializable() id: string;
     @serializable() label: string | null;
+    @serializable() labelTooltip: string | null;
+    @serializable() controlTooltip: string | null;
     @serializable() layout: DynamicFormControlLayout | null;
     @serializable() name: string;
     parent: DynamicPathable | null = null;
@@ -47,6 +51,8 @@ export abstract class DynamicFormControlModel implements DynamicPathable {
         this.hidden = typeof config.hidden === "boolean" ? config.hidden : false;
         this.id = config.id;
         this.label = config.label || null;
+        this.labelTooltip = config.labelTooltip || null;
+        this.controlTooltip = config.controlTooltip || null;
         this.layout = layout;
         this.name = config.name || config.id;
         this.relation = Array.isArray(config.relation) ? config.relation : [];


### PR DESCRIPTION
Hello, wanted to contribute a helpful addition to this wonderful forms library.

This PR adds two new properties to the DynamicFormControlModel, which can be used to set tooltip text for form labels and form controls independently from the description text that's populated below the form controls. Here are a couple of images to help visualize what this change allows one to do.

<img width="747" alt="screen shot 2018-02-22 at 3 49 16 pm" src="https://user-images.githubusercontent.com/5942899/36599770-6ec043bc-187e-11e8-8b42-a95aa6ff8824.png">

<img width="714" alt="screen shot 2018-02-22 at 3 49 26 pm" src="https://user-images.githubusercontent.com/5942899/36599771-6ec8eddc-187e-11e8-8e65-19aa309fcb72.png">

<img width="725" alt="screen shot 2018-02-22 at 3 50 05 pm" src="https://user-images.githubusercontent.com/5942899/36599772-6ed1fd00-187e-11e8-961f-df693700d8ea.png">

"labelHint" and "controlHint" are specific to our implementation, so please disregard those property names. These screenshots are just to illustrate how these new properties can be utilized to provide a more robust experience in a downstream project.

We are not using any of the UI libraries provided by ng-dynamic-forms, but instead have our own UI templates which we have extended to make use of these new model properties, among other things. You can see an example of how this is used here - https://github.com/seanforyou23/syndesis/blob/flexible-tooltips/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.html#L160

At risk of providing TMI, here's a related PR in our unrelated project, so you have all the context - https://github.com/syndesisio/syndesis/pull/1664

It could help solve issue https://github.com/udos86/ng-dynamic-forms/issues/700

Hope you find it helpful, let me know if you see any issues with these changes. Happy to work together to make this happen. Thank you!!