### PR TITLE
Add 'children' attribute to layout model

### DIFF
--- a/packages/core/src/model/misc/dynamic-form-control-layout.model.ts
+++ b/packages/core/src/model/misc/dynamic-form-control-layout.model.ts
@@ -1,5 +1,6 @@
 export interface DynamicFormControlLayoutConfig {
 
+    children?: string;
     container?: string;
     control?: string;
     errors?: string;

--- a/packages/ui-basic/src/form-array/dynamic-basic-form-array.component.html
+++ b/packages/ui-basic/src/form-array/dynamic-basic-form-array.component.html
@@ -17,7 +17,8 @@
                                         [layout]="layout"
                                         [model]="_model"
                                         [templates]="templates"
-                                        [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                        [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                    getClass('element','children'), getClass('grid','children')]"
                                         (blur)="onBlur($event)"
                                         (change)="onChange($event)"
                                         (focus)="onFocus($event)"

--- a/packages/ui-basic/src/form-group/dynamic-basic-form-group.component.html
+++ b/packages/ui-basic/src/form-group/dynamic-basic-form-group.component.html
@@ -13,7 +13,8 @@
                                     [layout]="layout"
                                     [model]="_model"
                                     [templates]="templates"
-                                    [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                    [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                getClass('element','children'), getClass('grid','children')]"
                                     (blur)="onBlur($event)"
                                     (change)="onChange($event)"
                                     (focus)="onFocus($event)"

--- a/packages/ui-bootstrap/src/form-array/dynamic-bootstrap-form-array.component.html
+++ b/packages/ui-bootstrap/src/form-array/dynamic-bootstrap-form-array.component.html
@@ -17,7 +17,8 @@
                                             [layout]="layout"
                                             [model]="_model"
                                             [templates]="templates"
-                                            [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                            [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                        getClass('element','children'), getClass('grid','children')]"
                                             (blur)="onBlur($event)"
                                             (change)="onChange($event)"
                                             (focus)="onFocus($event)"

--- a/packages/ui-bootstrap/src/form-group/dynamic-bootstrap-form-group.component.html
+++ b/packages/ui-bootstrap/src/form-group/dynamic-bootstrap-form-group.component.html
@@ -14,7 +14,8 @@
                                         [layout]="layout"
                                         [model]="_model"
                                         [templates]="templates"
-                                        [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                        [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                    getClass('element','children'), getClass('grid','children')]"
                                         (blur)="onBlur($event)"
                                         (change)="onChange($event)"
                                         (focus)="onFocus($event)"

--- a/packages/ui-foundation/src/form-array/dynamic-foundation-form-array.component.html
+++ b/packages/ui-foundation/src/form-array/dynamic-foundation-form-array.component.html
@@ -17,7 +17,8 @@
                                              [layout]="layout"
                                              [model]="_model"
                                              [templates]="templates"
-                                             [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                             [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                         getClass('element','children'), getClass('grid','children')]"
                                              (blur)="onBlur($event)"
                                              (change)="onChange($event)"
                                              (focus)="onFocus($event)"

--- a/packages/ui-foundation/src/form-group/dynamic-foundation-form-group.component.html
+++ b/packages/ui-foundation/src/form-group/dynamic-foundation-form-group.component.html
@@ -13,7 +13,8 @@
                                          [layout]="layout"
                                          [model]="_model"
                                          [templates]="templates"
-                                         [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                         [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                     getClass('element','children'), getClass('grid','children')]"
                                          (blur)="onBlur($event)"
                                          (change)="onChange($event)"
                                          (focus)="onFocus($event)"

--- a/packages/ui-ionic/src/form-array/dynamic-ionic-form-array.component.html
+++ b/packages/ui-ionic/src/form-array/dynamic-ionic-form-array.component.html
@@ -17,7 +17,8 @@
                                         [layout]="layout"
                                         [model]="_model"
                                         [templates]="templates"
-                                        [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                        [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                    getClass('element','children'), getClass('grid','children')]"
                                         (blur)="onBlur($event)"
                                         (change)="onChange($event)"
                                         (focus)="onFocus($event)"

--- a/packages/ui-ionic/src/form-group/dynamic-ionic-form-group.component.html
+++ b/packages/ui-ionic/src/form-group/dynamic-ionic-form-group.component.html
@@ -13,7 +13,8 @@
                                     [layout]="layout"
                                     [model]="_model"
                                     [templates]="templates"
-                                    [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                    [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                getClass('element','children'), getClass('grid','children')]"
                                     (blur)="onBlur($event)"
                                     (change)="onChange($event)"
                                     (focus)="onFocus($event)"

--- a/packages/ui-kendo/src/form-array/dynamic-kendo-form-array.component.html
+++ b/packages/ui-kendo/src/form-array/dynamic-kendo-form-array.component.html
@@ -17,7 +17,8 @@
                                         [layout]="layout"
                                         [model]="_model"
                                         [templates]="templates"
-                                        [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                        [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                    getClass('element','children'), getClass('grid','children')]"
                                         (blur)="onBlur($event)"
                                         (change)="onChange($event)"
                                         (focus)="onFocus($event)"

--- a/packages/ui-kendo/src/form-group/dynamic-kendo-form-group.component.html
+++ b/packages/ui-kendo/src/form-group/dynamic-kendo-form-group.component.html
@@ -11,7 +11,8 @@
                                     [layout]="layout"
                                     [model]="_model"
                                     [templates]="templates"
-                                    [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                    [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                getClass('element','children'), getClass('grid','children')]"
                                     (blur)="onBlur($event)"
                                     (change)="onChange($event)"
                                     (focus)="onFocus($event)"

--- a/packages/ui-material/src/form-array/dynamic-material-form-array.component.html
+++ b/packages/ui-material/src/form-array/dynamic-material-form-array.component.html
@@ -17,7 +17,8 @@
                                            [layout]="layout"
                                            [model]="_model"
                                            [templates]="templates"
-                                           [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                           [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                       getClass('element','children'), getClass('grid','children')]"
                                            (blur)="onBlur($event)"
                                            (change)="onChange($event)"
                                            (focus)="onFocus($event)"

--- a/packages/ui-material/src/form-group/dynamic-material-form-group.component.html
+++ b/packages/ui-material/src/form-group/dynamic-material-form-group.component.html
@@ -11,7 +11,8 @@
                                        [layout]="layout"
                                        [model]="_model"
                                        [templates]="templates"
-                                       [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                       [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                   getClass('element','children'), getClass('grid','children')]"
                                        (blur)="onBlur($event)"
                                        (change)="onChange($event)"
                                        (focus)="onFocus($event)"

--- a/packages/ui-ng-bootstrap/src/form-array/dynamic-ng-bootstrap-form-array.component.html
+++ b/packages/ui-ng-bootstrap/src/form-array/dynamic-ng-bootstrap-form-array.component.html
@@ -17,7 +17,8 @@
                                                [layout]="layout"
                                                [model]="_model"
                                                [templates]="templates"
-                                               [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                               [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                           getClass('element','children'), getClass('grid','children')]"
                                                (blur)="onBlur($event)"
                                                (change)="onChange($event)"
                                                (focus)="onFocus($event)"

--- a/packages/ui-ng-bootstrap/src/form-group/dynamic-ng-bootstrap-form-group.component.html
+++ b/packages/ui-ng-bootstrap/src/form-group/dynamic-ng-bootstrap-form-group.component.html
@@ -12,7 +12,8 @@
                                            [layout]="layout"
                                            [model]="_model"
                                            [templates]="templates"
-                                           [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                           [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                       getClass('element','children'), getClass('grid','children')]"
                                            (blur)="onBlur($event)"
                                            (change)="onChange($event)"
                                            (focus)="onFocus($event)"

--- a/packages/ui-primeng/src/form-array/dynamic-primeng-form-array.component.html
+++ b/packages/ui-primeng/src/form-array/dynamic-primeng-form-array.component.html
@@ -17,7 +17,8 @@
                                               [layout]="layout"
                                               [model]="_model"
                                               [templates]="templates"
-                                              [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                              [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                          getClass('element','children'), getClass('grid','children')]"
                                               (blur)="onBlur($event)"
                                               (change)="onChange($event)"
                                               (focus)="onFocus($event)"

--- a/packages/ui-primeng/src/form-group/dynamic-primeng-form-group.component.html
+++ b/packages/ui-primeng/src/form-group/dynamic-primeng-form-group.component.html
@@ -11,7 +11,8 @@
                                       [layout]="layout"
                                       [model]="_model "
                                       [templates]="templates"
-                                      [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
+                                      [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model),
+                                                  getClass('element','children'), getClass('grid','children')]"
                                       (blur)="onBlur($event)"
                                       (change)="onChange($event)"
                                       (focus)="onFocus($event)"


### PR DESCRIPTION
Adds the children attribute to the layout model, which has the same power as using the 'host' attribute on every children of the form control.

This works for 'FormGroups' and 'FormArrays' as they have the only reasonable children for this.

Improves working with css layout libraries such as Bootstrap, Bulma a.s.o. as you don't need to repeat the same class for all children if this is wished. ( meaning a symmetric layout )

Solves #821