### PR TITLE
Adding ability to use function with text-mask parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1196,6 +1196,18 @@ new DynamicInputModel({
 }),
 ```
 
+You can also pass a function as the mask. The function will receive the user input at every change. The function is expected to return a mask array as described above.[Text Mask Addons](https://github.com/text-mask/text-mask/tree/master/addons/)
+ ```typescript
+new DynamicInputModel({
+     id: "maskedInput",
+    label: "Masked Input",
+    mask: createNumberMask({
+            prefix: "",
+            suffix: " $"
+          }),
+}),
+```
+
 Please note that some UI libraries like Kendo UI come with their own text mask implementation that may rely on a different text mask string / regex representation.
 
 

--- a/packages/core/src/model/input/dynamic-input.model.spec.ts
+++ b/packages/core/src/model/input/dynamic-input.model.spec.ts
@@ -9,13 +9,24 @@ import { isString } from "../../utils/core.utils";
 describe("DynamicInputModel test suite", () => {
 
     let model: DynamicInputModel,
+        modelMaskFunction: DynamicInputModel,
         config = {
             id: "input",
             list: ["One", "Two", "Three"],
             mask: ["test", /[1-9]/]
+        },
+        configMaskFunction = {
+            id: "input",
+            list: ["One", "Two", "Three"],
+            mask: () => {
+                return ["(", /[1-9]/, /\d/, /\d/, ")", " ", /\d/, /\d/, /\d/, "-", /\d/, /\d/, /\d/, /\d/];
+            }
         };
 
-    beforeEach(() => model = new DynamicInputModel(config));
+    beforeEach(() => {
+        model = new DynamicInputModel(config);
+        modelMaskFunction = new DynamicInputModel(configMaskFunction);
+    });
 
     it("tests if correct default type property is set", () => {
 
@@ -120,4 +131,8 @@ describe("DynamicInputModel test suite", () => {
         expect(json.value).toBe(model.value);
         expect(json.type).toEqual(DYNAMIC_FORM_CONTROL_TYPE_INPUT);
     });
+
+    it("should apply function with text-mask parameters correctly", () => {
+        expect(modelMaskFunction.mask).toEqual(Function);
+   });
 });

--- a/packages/core/src/model/input/dynamic-input.model.ts
+++ b/packages/core/src/model/input/dynamic-input.model.ts
@@ -30,7 +30,7 @@ export interface DynamicInputModelConfig extends DynamicInputControlModelConfig<
     accept?: string;
     inputType?: string;
     list?: any[] | Observable<any[]>;
-    mask?: string | RegExp | (string | RegExp)[];
+    mask?: string | RegExp | Function | (string | RegExp)[];
     max?: number | string | Date;
     min?: number | string | Date;
     multiple?: boolean;
@@ -44,7 +44,7 @@ export class DynamicInputModel extends DynamicInputControlModel<string | number 
     @serializable() inputType: string;
     files: FileList | null = null;
     list$: Observable<any[]> | null = null;
-    @serializable() mask: string | RegExp | (string | RegExp)[] | null;
+    @serializable() mask: string | RegExp | Function | (string | RegExp)[] | null;
     @serializable() max: number | string | Date | null;
     @serializable() min: number | string | Date | null;
     @serializable() multiple: boolean | null;
@@ -106,7 +106,13 @@ export class DynamicInputModel extends DynamicInputControlModel<string | number 
 
         let json: any = super.toJSON();
 
-        if (this.mask !== null) { json.mask = maskToString(this.mask); }
+        if (this.mask !== null) { 
+            if (this.mask instanceof Function) {
+                json.mask = this.mask;
+            } else {
+                json.mask = maskToString(this.mask);
+            }
+        }
 
         return json;
     }

--- a/packages/core/src/service/dynamic-form.service.ts
+++ b/packages/core/src/service/dynamic-form.service.ts
@@ -370,7 +370,9 @@ export class DynamicFormService {
                     let inputModel = model as DynamicInputModel;
 
                     if (inputModel.mask !== null) {
-                        inputModel.mask = maskFromString(inputModel.mask as string);
+                        if (inputModel.mask instanceof Function === false) {
+                            inputModel.mask = maskFromString(inputModel.mask as string);
+                        }
                     }
 
                     formModel.push(new DynamicInputModel(model, layout));


### PR DESCRIPTION
This commit resolves #885
You can now pass a function with text-mask parameters.