### PR TITLE
ref(mask): Remove guide from masked input

### DIFF
--- a/packages/ui-basic/src/input/dynamic-basic-input.component.html
+++ b/packages/ui-basic/src/input/dynamic-basic-input.component.html
@@ -20,7 +20,7 @@
            [required]="model.required"
            [spellcheck]="model.spellCheck"
            [tabindex]="model.tabIndex"
-           [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder)}"
+           [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder), guide: false}"
            [type]="model.inputType"
            (blur)="onBlur($event)"
            (change)="onChange($event)"

--- a/packages/ui-bootstrap/src/input/dynamic-bootstrap-input.component.html
+++ b/packages/ui-bootstrap/src/input/dynamic-bootstrap-input.component.html
@@ -23,7 +23,7 @@
            [required]="model.required"
            [spellcheck]="model.spellCheck"
            [tabindex]="model.tabIndex"
-           [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder)}"
+           [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder, guide: false)}"
            [type]="model.inputType"
            (blur)="onBlur($event)"
            (change)="onChange($event)"

--- a/packages/ui-foundation/src/input/dynamic-foundation-input.component.html
+++ b/packages/ui-foundation/src/input/dynamic-foundation-input.component.html
@@ -24,7 +24,7 @@
            [required]="model.required"
            [spellcheck]="model.spellCheck"
            [tabindex]="model.tabIndex"
-           [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder)}"
+           [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder, guide: false)}"
            [type]="model.inputType"
            (blur)="onBlur($event)"
            (change)="onChange($event)"

--- a/packages/ui-material/src/input/dynamic-material-input.component.html
+++ b/packages/ui-material/src/input/dynamic-material-input.component.html
@@ -4,7 +4,7 @@
                 [formGroup]="group"
                 [hideRequiredMarker]="model.getAdditional('hideRequiredMarker', false)"
                 [ngClass]="getClass('grid','control')"
-                [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder)}">
+                [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder), guide: false}">
 
     <ng-container *ngIf="model.label" ngProjectAs="mat-label">
 

--- a/packages/ui-ng-bootstrap/src/input/dynamic-ng-bootstrap-input.component.html
+++ b/packages/ui-ng-bootstrap/src/input/dynamic-ng-bootstrap-input.component.html
@@ -27,7 +27,7 @@
            [required]="model.required"
            [spellcheck]="model.spellCheck"
            [tabindex]="model.tabIndex"
-           [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder)}"
+           [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder), guide: false}"
            [type]="model.inputType"
            (blur)="onBlur($event)"
            (change)="onChange($event)"


### PR DESCRIPTION
Because the package is appending an underline on input value.
Mentioned in https://github.com/text-mask/text-mask/issues/294#issuecomment-337974877.
Also, this improve the form aesthetics.