### PR TITLE
DynamicFormsInstanceService & support for additional form field components

### DIFF
--- a/bs-config.js
+++ b/bs-config.js
@@ -1,4 +1,4 @@
-let indexPath = "./sample/index.systemjs.html";
+let indexPath = "./sample/index.aot.html";
 
 module.exports = {
 

--- a/packages/core/src/component/dynamic-form-control-container.component.ts
+++ b/packages/core/src/component/dynamic-form-control-container.component.ts
@@ -368,13 +368,11 @@ export abstract class DynamicFormControlContainerComponent implements OnChanges,
 
     private registerInstance(instanceRef: ComponentRef<DynamicFormControl>): void {
         let index;
-        let model = this.model;
         if (this.context && this.context instanceof DynamicFormArrayGroupModel) {
             index = this.context.index;
-            model = this.context.context;
         }
 
-        this.dynamicFormInstanceService.setFormControlInstance(model, instanceRef, index);
+        this.dynamicFormInstanceService.setFormControlInstance(this.model, instanceRef, index);
     }
 
     private removeInstance(): void {

--- a/packages/core/src/component/dynamic-form-control-container.component.ts
+++ b/packages/core/src/component/dynamic-form-control-container.component.ts
@@ -368,11 +368,13 @@ export abstract class DynamicFormControlContainerComponent implements OnChanges,
 
     private registerInstance(instanceRef: ComponentRef<DynamicFormControl>): void {
         let index;
+        let model = this.model;
         if (this.context && this.context instanceof DynamicFormArrayGroupModel) {
             index = this.context.index;
+            model = this.context.context;
         }
 
-        this.dynamicFormInstanceService.setFormControlInstance(this.model, instanceRef, index);
+        this.dynamicFormInstanceService.setFormControlInstance(model, instanceRef, index);
     }
 
     private removeInstance(): void {

--- a/packages/core/src/core.module.ts
+++ b/packages/core/src/core.module.ts
@@ -7,6 +7,7 @@ import { DynamicTemplateDirective } from "./directive/dynamic-template.directive
 import { DynamicFormService } from "./service/dynamic-form.service";
 import { DynamicFormLayoutService } from "./service/dynamic-form-layout.service";
 import { DynamicFormValidationService } from "./service/dynamic-form-validation.service";
+import { DynamicFormInstancesService } from "./service/dynamic-form-instances.service";
 
 @NgModule({
     imports: [
@@ -35,7 +36,8 @@ export class DynamicFormsCoreModule {
             providers: [
                 DynamicFormService,
                 DynamicFormLayoutService,
-                DynamicFormValidationService
+                DynamicFormValidationService,
+                DynamicFormInstancesService
             ]
         };
     }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -47,6 +47,7 @@ export * from "./model/misc/dynamic-form-control-validation.model";
 export * from "./service/dynamic-form.service";
 export * from "./service/dynamic-form-layout.service";
 export * from "./service/dynamic-form-validation.service";
+export * from "./service/dynamic-form-instances.service";
 
 export * from "./utils/autofill.utils";
 export * from "./utils/core.utils";

--- a/packages/core/src/model/dynamic-form-value-control.model.ts
+++ b/packages/core/src/model/dynamic-form-value-control.model.ts
@@ -44,7 +44,7 @@ export abstract class DynamicFormValueControlModel<T> extends DynamicFormControl
         return this._value;
     }
 
-    getAdditional(key: string, defaultValue: any | null | undefined): any {
+    getAdditional(key: string, defaultValue: any | null | undefined = undefined): any {
         return this.additional !== null && this.additional.hasOwnProperty(key) ? this.additional[key] : defaultValue;
     }
 }

--- a/packages/core/src/service/dynamic-form-instances.service.spec.ts
+++ b/packages/core/src/service/dynamic-form-instances.service.spec.ts
@@ -16,7 +16,7 @@ export class TestComponentRef extends ComponentRef<any> {
     }
 
     onDestroy(callback: Function): void {
-        callback.call(() => null);
+        callback.call(async () => undefined);
     }
 
     constructor() {

--- a/packages/core/src/service/dynamic-form-instances.service.spec.ts
+++ b/packages/core/src/service/dynamic-form-instances.service.spec.ts
@@ -77,4 +77,15 @@ describe("DynamicFormInstanceService test suite", () => {
         service.removeFormControlInstance(model.id);
         expect(service.getFormControlInstance(model.id)).toBeUndefined();
     });
+
+    it("should throw exception when trying to delete non existent objects", () => {
+        const modelId: string = model.id;
+        const index: number = 0;
+        expect(function () {
+            service.removeFormControlInstance(modelId);
+        }).toThrowError(`There exists no control with id: ${modelId}`);
+        expect(function () {
+            service.removeFormControlInstance(modelId, 0);
+        }).toThrowError(`There exists no control with id: ${modelId} and/or index ${index}`);
+    });
 });

--- a/packages/core/src/service/dynamic-form-instances.service.spec.ts
+++ b/packages/core/src/service/dynamic-form-instances.service.spec.ts
@@ -1,0 +1,80 @@
+import { inject, TestBed } from "@angular/core/testing";
+import { DynamicFormControlModel } from "../model/dynamic-form-control.model";
+import { DynamicInputModel } from "../model/input/dynamic-input.model";
+import { DynamicFormInstancesService } from "./dynamic-form-instances.service";
+import { ChangeDetectorRef, ComponentRef, ElementRef, Injector, Type, ViewRef } from "@angular/core";
+
+export class TestComponentRef extends ComponentRef<any> {
+    readonly changeDetectorRef: ChangeDetectorRef;
+    readonly componentType: Type<any>;
+    readonly hostView: ViewRef;
+    readonly injector: Injector;
+    readonly instance: any;
+    readonly location: ElementRef;
+
+    destroy(): void {
+    }
+
+    onDestroy(callback: Function): void {
+        callback.call(() => null);
+    }
+
+    constructor() {
+        super();
+    }
+
+}
+
+describe("DynamicFormInstanceService test suite", () => {
+
+    let service: DynamicFormInstancesService;
+    let model: DynamicFormControlModel;
+
+    let instanceRef: TestComponentRef;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [DynamicFormInstancesService]
+        });
+
+        model = new DynamicInputModel({
+            id: "test"
+        });
+        instanceRef = new TestComponentRef();
+    });
+
+    beforeEach(inject([DynamicFormInstancesService],
+        (instanceService: DynamicFormInstancesService) => service = instanceService));
+
+
+    it("should be empty when nothing set", () => {
+        expect(service.getFormControlInstance(model.id)).toBeUndefined();
+    });
+
+    it("should have this reference when set", () => {
+        service.setFormControlInstance(model, instanceRef);
+        expect(service.getFormControlInstance(model.id)).toBe(instanceRef);
+    });
+
+    it("should not have this reference at the given index", () => {
+        service.setFormControlInstance(model, instanceRef);
+        expect(service.getFormControlInstance(model.id, 0)).toBeUndefined();
+    });
+
+    it("should have this reference after set to index", () => {
+        service.setFormControlInstance(model, instanceRef, 0);
+        expect(service.getFormControlInstance(model.id, 0)).toBe(instanceRef);
+    });
+
+    it("should no more have this reference at the given index, when deleted", () => {
+        service.setFormControlInstance(model, instanceRef, 0);
+        service.removeFormControlInstance(model.id, 0);
+        expect(service.getFormControlInstance(model.id, 0)).toBeUndefined();
+    });
+
+    it("should no more have this reference, when deleted", () => {
+        service.setFormControlInstance(model, instanceRef);
+        service.removeFormControlInstance(model.id);
+        expect(service.getFormControlInstance(model.id)).toBeUndefined();
+    });
+});

--- a/packages/core/src/service/dynamic-form-instances.service.ts
+++ b/packages/core/src/service/dynamic-form-instances.service.ts
@@ -35,13 +35,15 @@ export class DynamicFormInstancesService {
         const instanceRef = this.formControlInstances[modelId];
         if (index !== undefined) {
 
-            if (Array.isArray(instanceRef)) {
+            if (Array.isArray(instanceRef) && instanceRef[index]) {
                 instanceRef[index] = undefined;
+            } else {
+                throw new Error(`There exists no control with id: ${modelId} and/or index ${index}`);
             }
         } else if (instanceRef) {
             delete this.formControlInstances[modelId];
         } else {
-            throw new Error(`There exists no control with id: ${modelId} and/or index: ${index}`);
+            throw new Error(`There exists no control with id: ${modelId}`);
         }
     }
 

--- a/packages/core/src/service/dynamic-form-instances.service.ts
+++ b/packages/core/src/service/dynamic-form-instances.service.ts
@@ -1,0 +1,44 @@
+import { ComponentRef, Injectable } from "@angular/core";
+import { DynamicFormControl } from "../component/dynamic-form-control.interface";
+import { DynamicFormControlModel } from "../model/dynamic-form-control.model";
+
+@Injectable()
+export class DynamicFormInstancesService {
+
+    protected formControlInstances: { [key: string]: ComponentRef<DynamicFormControl> | Array<ComponentRef<DynamicFormControl>> } = {};
+
+    getFormControlInstance(modelId: string, index?: number): ComponentRef<DynamicFormControl> | undefined {
+        const retInstance: ComponentRef<DynamicFormControl> | Array<ComponentRef<DynamicFormControl>> =
+            this.formControlInstances[modelId];
+        if (Array.isArray(retInstance) && index) {
+            return retInstance[index];
+        } else {
+            return this.formControlInstances[modelId] as ComponentRef<DynamicFormControl>;
+        }
+
+    }
+
+    setFormControlInstance(model: DynamicFormControlModel, instance: ComponentRef<DynamicFormControl>, index?: number): void {
+        if (index !== undefined) {
+            const arrayRef: Array<ComponentRef<DynamicFormControl>> =
+                this.formControlInstances[model.id] as Array<ComponentRef<DynamicFormControl>> || [];
+            arrayRef[index] = instance;
+            this.formControlInstances[model.id] = arrayRef;
+        } else {
+            this.formControlInstances[model.id] = instance;
+        }
+    }
+
+    removeFormControlInstance(modelId: string, index?: number): void {
+        const instanceRef = this.formControlInstances[modelId];
+        if (index !== undefined) {
+
+            if (Array.isArray(instanceRef)) {
+                delete instanceRef[index];
+            }
+        } else {
+            delete this.formControlInstances[modelId];
+        }
+    }
+
+}

--- a/packages/core/src/service/dynamic-form-instances.service.ts
+++ b/packages/core/src/service/dynamic-form-instances.service.ts
@@ -41,7 +41,7 @@ export class DynamicFormInstancesService {
         } else if (instanceRef) {
             delete this.formControlInstances[modelId];
         } else {
-            throw new Error(`There exists no control with id: ${modelId} and/or index: ${index}`);
+            throw new Error(`There exists no control with id: ${modelId} and/or index: ${index !== undefined ? index : ""}`);
         }
     }
 

--- a/packages/core/src/service/dynamic-form-instances.service.ts
+++ b/packages/core/src/service/dynamic-form-instances.service.ts
@@ -41,7 +41,7 @@ export class DynamicFormInstancesService {
         } else if (instanceRef) {
             delete this.formControlInstances[modelId];
         } else {
-            throw new Error(`There exists no control with id: ${modelId} and/or index: ${index !== undefined ? index : ""}`);
+            throw new Error(`There exists no control with id: ${modelId} and/or index: ${index}`);
         }
     }
 

--- a/packages/core/src/service/dynamic-form-instances.service.ts
+++ b/packages/core/src/service/dynamic-form-instances.service.ts
@@ -2,18 +2,20 @@ import { ComponentRef, Injectable } from "@angular/core";
 import { DynamicFormControl } from "../component/dynamic-form-control.interface";
 import { DynamicFormControlModel } from "../model/dynamic-form-control.model";
 
-@Injectable()
+@Injectable({
+    providedIn: "root"
+})
 export class DynamicFormInstancesService {
 
-    protected formControlInstances: { [key: string]: ComponentRef<DynamicFormControl> | Array<ComponentRef<DynamicFormControl>> } = {};
+    protected formControlInstances: { [key: string]: ComponentRef<DynamicFormControl> | Array<ComponentRef<DynamicFormControl> | undefined> } = {};
 
     getFormControlInstance(modelId: string, index?: number): ComponentRef<DynamicFormControl> | undefined {
         const retInstance: ComponentRef<DynamicFormControl> | Array<ComponentRef<DynamicFormControl>> =
-            this.formControlInstances[modelId];
-        if (Array.isArray(retInstance) && index) {
+            this.formControlInstances[modelId] as ComponentRef<DynamicFormControl> | Array<ComponentRef<DynamicFormControl>>;
+        if (Array.isArray(retInstance) && index !== undefined) {
             return retInstance[index];
         } else {
-            return this.formControlInstances[modelId] as ComponentRef<DynamicFormControl>;
+            return index !== undefined ? undefined : this.formControlInstances[modelId] as ComponentRef<DynamicFormControl>;
         }
 
     }
@@ -29,15 +31,17 @@ export class DynamicFormInstancesService {
         }
     }
 
-    removeFormControlInstance(modelId: string, index?: number): void {
+    removeFormControlInstance(modelId: string, index?: number): void | never {
         const instanceRef = this.formControlInstances[modelId];
         if (index !== undefined) {
 
             if (Array.isArray(instanceRef)) {
-                delete instanceRef[index];
+                instanceRef[index] = undefined;
             }
-        } else {
+        } else if (instanceRef) {
             delete this.formControlInstances[modelId];
+        } else {
+            throw new Error(`There exists no control with id: ${modelId} and/or index: ${index}`);
         }
     }
 

--- a/packages/ui-basic/src/dynamic-basic-form-control-container.component.ts
+++ b/packages/ui-basic/src/dynamic-basic-form-control-container.component.ts
@@ -12,23 +12,24 @@ import {
 } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import {
-    DynamicFormArrayGroupModel,
-    DynamicFormControlContainerComponent,
-    DynamicFormControlEvent,
-    DynamicFormControlModel,
-    DynamicFormLayout,
-    DynamicFormLayoutService,
-    DynamicFormValidationService,
-    DynamicTemplateDirective,
-    DynamicFormControl,
     DYNAMIC_FORM_CONTROL_TYPE_ARRAY,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX_GROUP,
     DYNAMIC_FORM_CONTROL_TYPE_GROUP,
     DYNAMIC_FORM_CONTROL_TYPE_INPUT,
+    DYNAMIC_FORM_CONTROL_TYPE_RADIO_GROUP,
     DYNAMIC_FORM_CONTROL_TYPE_SELECT,
     DYNAMIC_FORM_CONTROL_TYPE_TEXTAREA,
-    DYNAMIC_FORM_CONTROL_TYPE_RADIO_GROUP
+    DynamicFormArrayGroupModel,
+    DynamicFormControl,
+    DynamicFormControlContainerComponent,
+    DynamicFormControlEvent,
+    DynamicFormControlModel,
+    DynamicFormInstancesService,
+    DynamicFormLayout,
+    DynamicFormLayoutService,
+    DynamicFormValidationService,
+    DynamicTemplateDirective
 } from "@ng-dynamic-forms/core";
 import { DynamicBasicCheckboxComponent } from "./checkbox/dynamic-basic-checkbox.component";
 import { DynamicBasicInputComponent } from "./input/dynamic-basic-input.component";
@@ -60,9 +61,10 @@ export class DynamicBasicFormControlContainerComponent extends DynamicFormContro
 
     constructor(protected componentFactoryResolver: ComponentFactoryResolver,
                 protected layoutService: DynamicFormLayoutService,
-                protected validationService: DynamicFormValidationService) {
+                protected validationService: DynamicFormValidationService,
+                protected dynamicFormInstancesService: DynamicFormInstancesService) {
 
-        super(componentFactoryResolver, layoutService, validationService);
+        super(componentFactoryResolver, layoutService, validationService, dynamicFormInstancesService);
     }
 
     get componentType(): Type<DynamicFormControl> | null {

--- a/packages/ui-bootstrap/src/dynamic-bootstrap-form-control-container.component.ts
+++ b/packages/ui-bootstrap/src/dynamic-bootstrap-form-control-container.component.ts
@@ -12,15 +12,6 @@ import {
 } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import {
-    DynamicFormArrayGroupModel,
-    DynamicFormControl,
-    DynamicFormControlContainerComponent,
-    DynamicFormControlEvent,
-    DynamicFormControlModel,
-    DynamicFormLayout,
-    DynamicFormLayoutService,
-    DynamicFormValidationService,
-    DynamicTemplateDirective,
     DYNAMIC_FORM_CONTROL_TYPE_ARRAY,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX_GROUP,
@@ -32,6 +23,16 @@ import {
     DYNAMIC_FORM_CONTROL_TYPE_SELECT,
     DYNAMIC_FORM_CONTROL_TYPE_TEXTAREA,
     DYNAMIC_FORM_CONTROL_TYPE_TIMEPICKER,
+    DynamicFormArrayGroupModel,
+    DynamicFormControl,
+    DynamicFormControlContainerComponent,
+    DynamicFormControlEvent,
+    DynamicFormControlModel,
+    DynamicFormInstancesService,
+    DynamicFormLayout,
+    DynamicFormLayoutService,
+    DynamicFormValidationService,
+    DynamicTemplateDirective
 } from "@ng-dynamic-forms/core";
 import { DynamicBootstrapCheckboxComponent } from "./checkbox/dynamic-bootstrap-checkbox.component";
 import { DynamicBootstrapDatePickerComponent } from "./datepicker/dynamic-bootstrap-datepicker.component";
@@ -72,9 +73,10 @@ export class DynamicBootstrapFormControlContainerComponent extends DynamicFormCo
 
     constructor(protected componentFactoryResolver: ComponentFactoryResolver,
                 protected layoutService: DynamicFormLayoutService,
-                protected validationService: DynamicFormValidationService) {
+                protected validationService: DynamicFormValidationService,
+                protected dynamicFormInstancesService: DynamicFormInstancesService) {
 
-        super(componentFactoryResolver, layoutService, validationService);
+        super(componentFactoryResolver, layoutService, validationService, dynamicFormInstancesService);
     }
 }
 

--- a/packages/ui-foundation/src/dynamic-foundation-form-control-container.component.ts
+++ b/packages/ui-foundation/src/dynamic-foundation-form-control-container.component.ts
@@ -5,7 +5,10 @@ import {
     EventEmitter,
     Input,
     Output,
-    QueryList, Type, ViewChild, ViewContainerRef
+    QueryList,
+    Type,
+    ViewChild,
+    ViewContainerRef
 } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import {
@@ -23,10 +26,11 @@ import {
     DynamicFormControlContainerComponent,
     DynamicFormControlEvent,
     DynamicFormControlModel,
+    DynamicFormInstancesService,
     DynamicFormLayout,
     DynamicFormLayoutService,
     DynamicFormValidationService,
-    DynamicTemplateDirective,
+    DynamicTemplateDirective
 } from "@ng-dynamic-forms/core";
 import { DynamicFoundationTextAreaComponent } from "./textarea/dynamic-foundation-textarea.component";
 import { DynamicFoundationSwitchComponent } from "./switch/dynamic-foundation-switch.component";
@@ -59,9 +63,10 @@ export class DynamicFoundationFormControlContainerComponent extends DynamicFormC
 
     constructor(protected componentFactoryResolver: ComponentFactoryResolver,
                 protected layoutService: DynamicFormLayoutService,
-                protected validationService: DynamicFormValidationService) {
+                protected validationService: DynamicFormValidationService,
+                protected dynamicFormInstancesService: DynamicFormInstancesService) {
 
-        super(componentFactoryResolver, layoutService, validationService);
+        super(componentFactoryResolver, layoutService, validationService, dynamicFormInstancesService);
     }
 
     get componentType(): Type<DynamicFormControl> | null {

--- a/packages/ui-ionic/src/dynamic-ionic-form-control-container.component.ts
+++ b/packages/ui-ionic/src/dynamic-ionic-form-control-container.component.ts
@@ -6,19 +6,12 @@ import {
     Input,
     Output,
     QueryList,
-    Type, ViewChild, ViewContainerRef
+    Type,
+    ViewChild,
+    ViewContainerRef
 } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import {
-    DynamicFormArrayGroupModel,
-    DynamicFormControl,
-    DynamicFormControlContainerComponent,
-    DynamicFormControlEvent,
-    DynamicFormControlModel,
-    DynamicFormLayout,
-    DynamicFormLayoutService,
-    DynamicFormValidationService,
-    DynamicTemplateDirective,
     DYNAMIC_FORM_CONTROL_TYPE_ARRAY,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX_GROUP,
@@ -30,7 +23,17 @@ import {
     DYNAMIC_FORM_CONTROL_TYPE_SLIDER,
     DYNAMIC_FORM_CONTROL_TYPE_SWITCH,
     DYNAMIC_FORM_CONTROL_TYPE_TEXTAREA,
-    DYNAMIC_FORM_CONTROL_TYPE_TIMEPICKER
+    DYNAMIC_FORM_CONTROL_TYPE_TIMEPICKER,
+    DynamicFormArrayGroupModel,
+    DynamicFormControl,
+    DynamicFormControlContainerComponent,
+    DynamicFormControlEvent,
+    DynamicFormControlModel,
+    DynamicFormInstancesService,
+    DynamicFormLayout,
+    DynamicFormLayoutService,
+    DynamicFormValidationService,
+    DynamicTemplateDirective
 } from "@ng-dynamic-forms/core";
 import { DynamicIonicCheckboxComponent } from "./checkbox/dynamic-ionic-checkbox.component";
 import { DynamicIonicDateTimeComponent } from "./datetime/dynamic-ionic-datetime.component";
@@ -66,9 +69,10 @@ export class DynamicIonicFormControlContainerComponent extends DynamicFormContro
 
     constructor(protected componentFactoryResolver: ComponentFactoryResolver,
                 protected layoutService: DynamicFormLayoutService,
-                protected validationService: DynamicFormValidationService) {
+                protected validationService: DynamicFormValidationService,
+                protected dynamicFormInstancesService: DynamicFormInstancesService) {
 
-        super(componentFactoryResolver, layoutService, validationService);
+        super(componentFactoryResolver, layoutService, validationService, dynamicFormInstancesService);
     }
 
     get componentType(): Type<DynamicFormControl> | null {

--- a/packages/ui-kendo/src/dynamic-kendo-form-control-container.component.ts
+++ b/packages/ui-kendo/src/dynamic-kendo-form-control-container.component.ts
@@ -6,22 +6,14 @@ import {
     Input,
     Output,
     QueryList,
-    Type, ViewChild, ViewContainerRef,
+    Type,
+    ViewChild,
+    ViewContainerRef,
 } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import {
-    DynamicFormArrayGroupModel,
-    DynamicFormControl,
-    DynamicFormControlContainerComponent,
-    DynamicFormControlEvent,
-    DynamicFormControlModel,
-    DynamicFormLayout,
-    DynamicFormLayoutService,
-    DynamicFormValidationService,
-    DynamicTemplateDirective,
-    DynamicInputModel,
-    DynamicSelectModel,
-    DynamicDatePickerModel,
+    DYNAMIC_FORM_CONTROL_INPUT_TYPE_DATE,
+    DYNAMIC_FORM_CONTROL_INPUT_TYPE_NUMBER,
     DYNAMIC_FORM_CONTROL_TYPE_ARRAY,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX_GROUP,
@@ -35,9 +27,20 @@ import {
     DYNAMIC_FORM_CONTROL_TYPE_SWITCH,
     DYNAMIC_FORM_CONTROL_TYPE_TEXTAREA,
     DYNAMIC_FORM_CONTROL_TYPE_TIMEPICKER,
-    DYNAMIC_FORM_CONTROL_INPUT_TYPE_DATE,
-    DYNAMIC_FORM_CONTROL_INPUT_TYPE_NUMBER,
+    DynamicDatePickerModel,
+    DynamicFormArrayGroupModel,
+    DynamicFormControl,
+    DynamicFormControlContainerComponent,
+    DynamicFormControlEvent,
+    DynamicFormControlModel,
+    DynamicFormInstancesService,
+    DynamicFormLayout,
+    DynamicFormLayoutService,
+    DynamicFormValidationService,
     DynamicFormValueControlModel,
+    DynamicInputModel,
+    DynamicSelectModel,
+    DynamicTemplateDirective,
     isString
 } from "@ng-dynamic-forms/core";
 import { DynamicKendoAutoCompleteComponent } from "./autocomplete/dynamic-kendo-autocomplete.component";
@@ -83,9 +86,10 @@ export class DynamicKendoFormControlContainerComponent extends DynamicFormContro
 
     constructor(protected componentFactoryResolver: ComponentFactoryResolver,
                 protected layoutService: DynamicFormLayoutService,
-                protected validationService: DynamicFormValidationService) {
+                protected validationService: DynamicFormValidationService,
+                protected dynamicFormInstancesService: DynamicFormInstancesService) {
 
-        super(componentFactoryResolver, layoutService, validationService);
+        super(componentFactoryResolver, layoutService, validationService, dynamicFormInstancesService);
     }
 
     get componentType(): Type<DynamicFormControl> | null {

--- a/packages/ui-material/src/dynamic-material-form-control-container.component.ts
+++ b/packages/ui-material/src/dynamic-material-form-control-container.component.ts
@@ -34,6 +34,7 @@ import {
     DynamicFormValidationService,
     DynamicInputModel,
     DynamicTemplateDirective,
+    DynamicFormValueControlModel,
 } from "@ng-dynamic-forms/core";
 import { DynamicMaterialDatePickerComponent } from "./datepicker/dynamic-material-datepicker.component";
 import { DynamicMaterialInputComponent } from "./input/dynamic-material-input.component";
@@ -85,7 +86,10 @@ export class DynamicMaterialFormControlContainerComponent extends DynamicFormCon
         let matFormFieldTypes = [DYNAMIC_FORM_CONTROL_TYPE_DATEPICKER, DYNAMIC_FORM_CONTROL_TYPE_INPUT,
             DYNAMIC_FORM_CONTROL_TYPE_SELECT, DYNAMIC_FORM_CONTROL_TYPE_TEXTAREA];
 
-        return matFormFieldTypes.some(type => this.model.type === type);
+        return matFormFieldTypes.some(type => this.model.type === type) || (
+            this.model instanceof DynamicFormValueControlModel &&
+            this.model.getAdditional("isFormFieldControl")
+        );
     }
 }
 

--- a/packages/ui-material/src/dynamic-material-form-control-container.component.ts
+++ b/packages/ui-material/src/dynamic-material-form-control-container.component.ts
@@ -28,6 +28,7 @@ import {
     DynamicFormControlContainerComponent,
     DynamicFormControlEvent,
     DynamicFormControlModel,
+    DynamicFormInstancesService,
     DynamicFormLayout,
     DynamicFormLayoutService,
     DynamicFormValidationService,
@@ -69,9 +70,10 @@ export class DynamicMaterialFormControlContainerComponent extends DynamicFormCon
 
     constructor(protected componentFactoryResolver: ComponentFactoryResolver,
                 protected layoutService: DynamicFormLayoutService,
-                protected validationService: DynamicFormValidationService,) {
+                protected validationService: DynamicFormValidationService,
+                protected dynamicFormInstancesService: DynamicFormInstancesService) {
 
-        super(componentFactoryResolver, layoutService, validationService);
+        super(componentFactoryResolver, layoutService, validationService, dynamicFormInstancesService);
     }
 
     get componentType(): Type<DynamicFormControl> | null {

--- a/packages/ui-ng-bootstrap/src/dynamic-ng-bootstrap-form-control-container.component.ts
+++ b/packages/ui-ng-bootstrap/src/dynamic-ng-bootstrap-form-control-container.component.ts
@@ -12,15 +12,6 @@ import {
 } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import {
-    DynamicFormArrayGroupModel,
-    DynamicFormControl,
-    DynamicFormControlContainerComponent,
-    DynamicFormControlEvent,
-    DynamicFormControlModel,
-    DynamicFormLayout,
-    DynamicFormLayoutService,
-    DynamicFormValidationService,
-    DynamicTemplateDirective,
     DYNAMIC_FORM_CONTROL_TYPE_ARRAY,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX_GROUP,
@@ -32,7 +23,17 @@ import {
     DYNAMIC_FORM_CONTROL_TYPE_SELECT,
     DYNAMIC_FORM_CONTROL_TYPE_TEXTAREA,
     DYNAMIC_FORM_CONTROL_TYPE_TIMEPICKER,
-    DynamicDatePickerModel
+    DynamicDatePickerModel,
+    DynamicFormArrayGroupModel,
+    DynamicFormControl,
+    DynamicFormControlContainerComponent,
+    DynamicFormControlEvent,
+    DynamicFormControlModel,
+    DynamicFormInstancesService,
+    DynamicFormLayout,
+    DynamicFormLayoutService,
+    DynamicFormValidationService,
+    DynamicTemplateDirective
 } from "@ng-dynamic-forms/core";
 import { DynamicNGBootstrapCheckboxComponent } from "./checkbox/dynamic-ng-bootstrap-checkbox.component";
 import { DynamicNGBootstrapCheckboxGroupComponent } from "./checkbox-group/dynamic-ng-bootstrap-checkbox-group.component";
@@ -71,9 +72,10 @@ export class DynamicNGBootstrapFormControlContainerComponent extends DynamicForm
 
     constructor(protected componentFactoryResolver: ComponentFactoryResolver,
                 protected layoutService: DynamicFormLayoutService,
-                protected validationService: DynamicFormValidationService) {
+                protected validationService: DynamicFormValidationService,
+                protected dynamicFormInstancesService: DynamicFormInstancesService) {
 
-        super(componentFactoryResolver, layoutService, validationService);
+        super(componentFactoryResolver, layoutService, validationService, dynamicFormInstancesService);
     }
 
     get componentType(): Type<DynamicFormControl> | null {

--- a/packages/ui-primeng/src/dynamic-primeng-form-control-container.component.ts
+++ b/packages/ui-primeng/src/dynamic-primeng-form-control-container.component.ts
@@ -12,17 +12,7 @@ import {
 } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import {
-    DynamicFormArrayGroupModel,
-    DynamicFormControl,
-    DynamicFormControlContainerComponent,
-    DynamicFormControlEvent,
-    DynamicFormControlModel,
-    DynamicFormLayout,
-    DynamicFormLayoutService,
-    DynamicFormValidationService,
-    DynamicTemplateDirective,
-    DynamicInputModel,
-    DynamicSelectModel,
+    DYNAMIC_FORM_CONTROL_INPUT_TYPE_NUMBER,
     DYNAMIC_FORM_CONTROL_TYPE_ARRAY,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX,
     DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX_GROUP,
@@ -31,14 +21,25 @@ import {
     DYNAMIC_FORM_CONTROL_TYPE_EDITOR,
     DYNAMIC_FORM_CONTROL_TYPE_GROUP,
     DYNAMIC_FORM_CONTROL_TYPE_INPUT,
-    DYNAMIC_FORM_CONTROL_INPUT_TYPE_NUMBER,
     DYNAMIC_FORM_CONTROL_TYPE_RADIO_GROUP,
     DYNAMIC_FORM_CONTROL_TYPE_RATING,
     DYNAMIC_FORM_CONTROL_TYPE_SELECT,
     DYNAMIC_FORM_CONTROL_TYPE_SLIDER,
     DYNAMIC_FORM_CONTROL_TYPE_SWITCH,
     DYNAMIC_FORM_CONTROL_TYPE_TEXTAREA,
-    DYNAMIC_FORM_CONTROL_TYPE_TIMEPICKER
+    DYNAMIC_FORM_CONTROL_TYPE_TIMEPICKER,
+    DynamicFormArrayGroupModel,
+    DynamicFormControl,
+    DynamicFormControlContainerComponent,
+    DynamicFormControlEvent,
+    DynamicFormControlModel,
+    DynamicFormInstancesService,
+    DynamicFormLayout,
+    DynamicFormLayoutService,
+    DynamicFormValidationService,
+    DynamicInputModel,
+    DynamicSelectModel,
+    DynamicTemplateDirective
 } from "@ng-dynamic-forms/core";
 import { DynamicPrimeNGCheckboxComponent } from "./checkbox/dynamic-primeng-checkbox.component";
 import { DynamicPrimeNGColorPickerComponent } from "./colorpicker/dynamic-primeng-colorpicker.component";
@@ -82,9 +83,10 @@ export class DynamicPrimeNGFormControlContainerComponent extends DynamicFormCont
 
     constructor(protected componentFactoryResolver: ComponentFactoryResolver,
                 protected layoutService: DynamicFormLayoutService,
-                protected validationService: DynamicFormValidationService) {
+                protected validationService: DynamicFormValidationService,
+                protected dynamicFormInstancesService: DynamicFormInstancesService) {
 
-        super(componentFactoryResolver, layoutService, validationService);
+        super(componentFactoryResolver, layoutService, validationService, dynamicFormInstancesService);
     }
 
     get componentType(): Type<DynamicFormControl> | null {

--- a/sample/app/app.module.ts
+++ b/sample/app/app.module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from "@angular/core";
-import { Http, BaseRequestOptions } from "@angular/http";
+import { BaseRequestOptions, Http } from "@angular/http";
 import { HttpClientModule } from "@angular/common/http";
 import { MAT_CHIPS_DEFAULT_OPTIONS, MatCardModule, MatNativeDateModule } from "@angular/material";
 import { MockBackend } from "@angular/http/testing";
 import { BrowserModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { LocationStrategy, HashLocationStrategy } from "@angular/common";
-import { ReactiveFormsModule, NG_VALIDATORS, NG_ASYNC_VALIDATORS } from "@angular/forms";
+import { HashLocationStrategy, LocationStrategy } from "@angular/common";
+import { NG_ASYNC_VALIDATORS, NG_VALIDATORS, ReactiveFormsModule } from "@angular/forms";
 import { NgbDatepickerModule, NgbRatingModule, NgbTimepickerModule } from "@ng-bootstrap/ng-bootstrap";
 import { BsDatepickerModule, TimepickerModule } from "ngx-bootstrap";
 
@@ -31,10 +31,10 @@ import { ValidationMessageComponent } from "./validation-message/validation-mess
 import { AppRoutingModule } from './app.routing.module';
 import { AppComponent } from './app.component';
 import {
-    customValidator,
+    customAsyncFormGroupValidator,
     customDateRangeValidator,
     customForbiddenValidator,
-    customAsyncFormGroupValidator
+    customValidator
 } from "./app.validators";
 
 export function mockBackendFactory(mockBackend: MockBackend, baseRequestOptions: BaseRequestOptions) {
@@ -56,7 +56,7 @@ export function mockBackendFactory(mockBackend: MockBackend, baseRequestOptions:
         NgbDatepickerModule,
         NgbRatingModule,
         NgbTimepickerModule,
-        DynamicFormsCoreModule,
+        DynamicFormsCoreModule.forRoot(),
         DynamicFormsBasicUIModule,
         DynamicFormsBootstrapUIModule,
         DynamicFormsFoundationUIModule,

--- a/sample/app/app.routing.module.ts
+++ b/sample/app/app.routing.module.ts
@@ -1,4 +1,4 @@
-import { RouterModule, Route } from "@angular/router";
+import { Route, RouterModule } from "@angular/router";
 import { BasicSampleFormComponent } from "./ui-basic/basic-sample-form.component";
 import { BootstrapSampleFormComponent } from "./ui-bootstrap/bootstrap-sample-form.component";
 import { FoundationSampleFormComponent } from "./ui-foundation/foundation-sample-form.component";
@@ -79,10 +79,10 @@ const APP_ROUTES: Route[] = [
             bgColor: "#DB2226"
         }
     },
-    {
-        path: "lazy-loaded-form",
-        loadChildren: "./app/lazy-loaded/lazy-loaded-form.module#LazyLoadedFormModule"
-    }
+    // {
+    //     path: "lazy-loaded-form",
+    //     loadChildren: "./app/lazy-loaded/lazy-loaded-form.module#LazyLoadedFormModule"
+    // }
 ];
 
 @NgModule({


### PR DESCRIPTION
As this was requested now a few times, I sat down and created a service which allows to retrieve the ComponentRef<DynamicFormControl> of a form model object.

This will hopefully provide a way to solve some of the issues like #899 , #852, #806 

How to use:

First the service needs to be provided, this can be done either by using the 'forRoot()' on the CoreModule, or by simply providing it in a module or at component level. This also means for people not using 'forRoot()' this be a breaking change as they has to provide it additionally.

Next you inject the service in any component and/or service the name is as stated : 'DynamicFormsInstanceService'

After the view has inialized ( ngAfterViewInit ), one is able to call 'getFormControlInstance(modelId: string, index?: number)'. This will return a ComponentRef to the DynamicFormControl with the given id ( and index for form array elements ).

One thing which can cause issues here is if the same id is used multiple times ( except for FormArrays ), but this can solved by seperating elements with the same id into different components/modules and providing the service additionally for this components/modules.

Edit: Also added support for an 'isFormFieldControl' property in 'additional'. This allows for to mark a model as form field control and is useful when adding own material form field controls, but don't override existing ones. 