### PR TITLE
Issue #928 - ui-material DynamicInputModel accepting Array<any> 

### DIFF
--- a/packages/ui-material/src/input/dynamic-material-input.component.html
+++ b/packages/ui-material/src/input/dynamic-material-input.component.html
@@ -57,6 +57,13 @@
                   [displayWith]="model.getAdditional('displayWith', null)"
                   (optionSelected)="onChange($event)">
 
-    <mat-option *ngFor="let option of model.list$ | async" [value]="option">{{ option }}</mat-option>
+    <ng-container *ngIf="model.getAdditional('matAutocomplete', null) === null; else displayWith">
+        <mat-option *ngFor="let option of model.list$ | async" [value]="option">{{ option }}</mat-option>
+    </ng-container>
+    <ng-template #displayWith>
+        <mat-option *ngFor="let option of model.list$ | async" [value]="option">
+            {{ option[model.getAdditional('optionLabel', 'label')] }}
+        </mat-option>
+    </ng-template>
 
 </mat-autocomplete>


### PR DESCRIPTION
Issue #928 - ui-material DynamicInputModel accepting Array<any>  as List items with proper option display

change dynamic-material-input.component.html to set mat-option using value of additional.optionLabel value or 'label' if not set as the mat-option display value if additional.matAutocomplete is not null ( to use in conjunction with additional.displayWith ).