### PR TITLE
Bug fix. Use splice instead of default setting for form arrays in instance service.

### DIFF
--- a/packages/core/src/service/dynamic-form-instances-explicit.service.spec.ts
+++ b/packages/core/src/service/dynamic-form-instances-explicit.service.spec.ts
@@ -68,8 +68,17 @@ describe("DynamicFormInstanceService test suite", () => {
         expect(service.getFormControlInstance(model.id, 0)).toBe(instanceRef);
     });
 
-    it("should no more have this reference at the given index, when deleted", () => {
+    it("should still have this reference at the given index, when deleting the first one", () => {
         service.setFormControlInstance(model, instanceRef, 0);
+        service.setFormControlInstance(model, instanceRef, 1);
+        service.removeFormControlInstance(model.id, 0);
+        expect(service.getFormControlInstance(model.id, 0)).toBeDefined();
+    });
+
+    it("should no more have this reference at the given index, when deleting the first one two times", () => {
+        service.setFormControlInstance(model, instanceRef, 0);
+        service.setFormControlInstance(model, instanceRef, 1);
+        service.removeFormControlInstance(model.id, 0);
         service.removeFormControlInstance(model.id, 0);
         expect(service.getFormControlInstance(model.id, 0)).toBeUndefined();
     });

--- a/packages/core/src/service/dynamic-form-instances-explicit.service.ts
+++ b/packages/core/src/service/dynamic-form-instances-explicit.service.ts
@@ -28,9 +28,10 @@ export class DynamicFormInstancesExplicitService implements DynamicFormInstances
 
             const arrayRef: Array<ComponentRef<DynamicFormControl>> =
                 this.formControlInstances[model.id] as Array<ComponentRef<DynamicFormControl>> || [];
-
-            arrayRef[index] = instance;
-
+            /**
+             * Use splice to add element
+             */
+            arrayRef.splice(index, 0, instance);
             this.formControlInstances[model.id] = arrayRef;
 
         } else {
@@ -45,7 +46,10 @@ export class DynamicFormInstancesExplicitService implements DynamicFormInstances
         if (index !== undefined) {
 
             if (Array.isArray(instanceRef) && instanceRef[index]) {
-                instanceRef[index] = undefined;
+                /**
+                 * Use splice to remove elements
+                 */
+                instanceRef.splice(index, 1);
             } else {
                 throw new Error(`There exists no control with id: ${modelId} and/or index ${index}`);
             }


### PR DESCRIPTION
Should fix #933 