### PR TITLE
catered for `0` in null check for `parseErrorMessageConfig`.

### DIFF
--- a/packages/core/src/service/dynamic-form-validation.service.ts
+++ b/packages/core/src/service/dynamic-form-validation.service.ts
@@ -95,7 +95,7 @@ export class DynamicFormValidationService {
                 propertyName = expression.replace("validator.", "");
             }
 
-            return propertySource[propertyName] ? propertySource[propertyName] : null;
+            return propertySource[propertyName] === null || propertySource[propertyName] === undefined ? propertySource[propertyName] : null;
         });
     }
 

--- a/packages/core/src/service/dynamic-form-validation.service.ts
+++ b/packages/core/src/service/dynamic-form-validation.service.ts
@@ -95,7 +95,7 @@ export class DynamicFormValidationService {
                 propertyName = expression.replace("validator.", "");
             }
 
-            return propertySource[propertyName] === null || propertySource[propertyName] === undefined ? propertySource[propertyName] : null;
+            return propertySource[propertyName] !== null && propertySource[propertyName] !== undefined ? propertySource[propertyName] : null;
         });
     }
 


### PR DESCRIPTION
https://github.com/udos86/ng-dynamic-forms/issues/951