### PR TITLE
#989 PrimeNG spinners do not work unless a min/max value is specified

### DIFF
--- a/projects/ng-dynamic-forms/ui-primeng/src/lib/spinner/dynamic-primeng-spinner.component.html
+++ b/projects/ng-dynamic-forms/ui-primeng/src/lib/spinner/dynamic-primeng-spinner.component.html
@@ -3,8 +3,8 @@
     <p-spinner #pSpinner
                [formControlName]="model.id"
                [id]="elementId"
-               [min]="model.min"
-               [max]="model.max"
+               [min]="model.min === null ? undefined : model.min"
+               [max]="model.max === null ? undefined : model.max"
                [ngClass]="getClass('element', 'control')"
                [placeholder]="model.placeholder"
                [step]="model.step || 1"


### PR DESCRIPTION
Fallback to undefined if the min or max value is null for the prime spinner component

https://github.com/udos86/ng-dynamic-forms/issues/989