### PR TITLE
 feat(core): support transforming config before model creation

### DIFF
--- a/projects/ng-dynamic-forms/core/src/lib/service/dynamic-form.service.spec.ts
+++ b/projects/ng-dynamic-forms/core/src/lib/service/dynamic-form.service.spec.ts
@@ -7,7 +7,12 @@ import {
     NG_VALIDATORS,
     NG_ASYNC_VALIDATORS
 } from "@angular/forms";
-import { DYNAMIC_FORM_CONTROL_JSON_TRANSFORMER_MAP_FN, DynamicFormService, ModelJSONTransformFn } from './dynamic-form.service';
+import {
+    DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY,
+    DynamicFormControlJSONTransformFnArray,
+    DynamicFormService,
+    ModelJSONTransformFn
+} from './dynamic-form.service';
 import { DynamicFormValidationService } from "./dynamic-form-validation.service";
 import { DynamicFormModel } from "../model/dynamic-form.model";
 import { DynamicCheckboxModel } from "../model/checkbox/dynamic-checkbox.model";
@@ -220,27 +225,28 @@ describe("DynamicFormService test suite", () => {
 
 
     it("should transform dynamic form control JSON", () => {
-        const addSuffixIfRequired: (suffix: string) => ModelJSONTransformFn<DynamicInputModel> = (suffix: string) => (jsonModel) => {
+        const addLabelSuffixIfRequired: (suffix: string) => ModelJSONTransformFn<DynamicInputModel> = (suffix: string) => (jsonModel) => {
             if (jsonModel.validators && jsonModel.validators.required === null) {
-                jsonModel.name = `${jsonModel.name}${suffix}`;
+                jsonModel.label = `${jsonModel.label}${suffix}`;
             }
             return jsonModel;
         },
           model = new DynamicInputModel({
-              id: 'test',
-              name: 'test',
+              id: 'name',
+              name: 'name',
+              label: 'Name',
               validators: { required: null }
           });
 
         TestBed.overrideProvider(DynamicFormService,
           { deps: [{
-              provide: DYNAMIC_FORM_CONTROL_JSON_TRANSFORMER_MAP_FN,
-              useValue: [addSuffixIfRequired('*')]
+              provide: DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY,
+              useValue: [addLabelSuffixIfRequired('*')] as DynamicFormControlJSONTransformFnArray
           }]});
 
         inject([DynamicFormService], (formService) => {
-            expect(formService.getCustomJSONTransformer(model)).toBeDefined();
-            expect(formService.getCustomJSONTransformer(model)).toEqual(jasmine.objectContaining({ name: 'test*' }));
+            expect(formService.getCustomJSONTransform(model)).toBeDefined();
+            expect(formService.getCustomJSONTransform(model)).toEqual(jasmine.objectContaining({ labell: 'Name*' }));
         });
     });
 

--- a/projects/ng-dynamic-forms/core/src/lib/service/dynamic-form.service.ts
+++ b/projects/ng-dynamic-forms/core/src/lib/service/dynamic-form.service.ts
@@ -50,9 +50,9 @@ import { isFunction, isString } from '../utils/core.utils';
 
 export type ModelJSONTransformFn<T> = (modelJSON: T) => T;
 
-export type DynamicFormControlJSONTransformerMapFn<T = any> = (modelJSON: T) => ModelJSONTransformFn<T>[];
-export const DYNAMIC_FORM_CONTROL_JSON_TRANSFORMER_MAP_FN = new InjectionToken<DynamicFormControlJSONTransformerMapFn>(
-  'DYNAMIC_FORM_CONTROL_JSON_TRANSFORMER_MAP_FN'
+export type DynamicFormControlJSONTransformFnArray<T = any> = ModelJSONTransformFn<T>[];
+export const DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY = new InjectionToken<DynamicFormControlJSONTransformFnArray>(
+  'DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY'
 );
 
 @Injectable({
@@ -61,8 +61,8 @@ export const DYNAMIC_FORM_CONTROL_JSON_TRANSFORMER_MAP_FN = new InjectionToken<D
 export class DynamicFormService {
 
     constructor(private validationService: DynamicFormValidationService,
-                @Inject(DYNAMIC_FORM_CONTROL_JSON_TRANSFORMER_MAP_FN) @Optional() private readonly DYNAMIC_FORM_CONTROL_JSON_TRANSFORMER_MAP_FN: any) {
-        this.DYNAMIC_FORM_CONTROL_JSON_TRANSFORMER_MAP_FN = DYNAMIC_FORM_CONTROL_JSON_TRANSFORMER_MAP_FN as DynamicFormControlJSONTransformerMapFn;
+                @Inject(DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY) @Optional() private readonly DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY: any) {
+        this.DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY = DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY as DynamicFormControlJSONTransformFnArray;
     }
 
 
@@ -331,7 +331,7 @@ export class DynamicFormService {
             formModel: DynamicFormModel = [];
 
         formModelJSON.forEach((model: any) => {
-            model = this.getCustomJSONTransformer(model);
+            model = this.getCustomJSONTransform(model);
             let layout = model.layout || null;
 
             switch (model.type) {
@@ -432,9 +432,9 @@ export class DynamicFormService {
         return formModel;
     }
 
-    getCustomJSONTransformer(model: object): object {
-        return isFunction(this.DYNAMIC_FORM_CONTROL_JSON_TRANSFORMER_MAP_FN)
-          ? pipe(...this.DYNAMIC_FORM_CONTROL_JSON_TRANSFORMER_MAP_FN)(model)
+    getCustomJSONTransform(model: object): object {
+        return isFunction(this.DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY)
+          ? pipe(...this.DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY)(model)
           : model;
     }
 }

--- a/projects/ng-dynamic-forms/core/src/lib/utils/json.utils.spec.ts
+++ b/projects/ng-dynamic-forms/core/src/lib/utils/json.utils.spec.ts
@@ -43,11 +43,11 @@ describe("JSON utils test suite", () => {
 
     it("should pass object in multiple functions", () => {
        const object = { id: 'test' },
-            transformer = (modifier: string) => (x: any) => {
+            modifyId = (modifier: string) => (x: any) => {
            x.id = `${x.id}${modifier}`;
            return x;
        };
 
-       expect(pipe(transformer('1'), transformer('2'))(object)).toEqual(jasmine.objectContaining({ id: 'test12' }));
+       expect(pipe(modifyId('1'), modifyId('2'))(object)).toEqual(jasmine.objectContaining({ id: 'test12' }));
     });
 });

--- a/projects/ng-dynamic-forms/core/src/lib/utils/json.utils.spec.ts
+++ b/projects/ng-dynamic-forms/core/src/lib/utils/json.utils.spec.ts
@@ -1,4 +1,4 @@
-import { maskFromString, maskToString, parseReviver } from "./json.utils";
+import { maskFromString, maskToString, parseReviver, pipe } from './json.utils';
 
 describe("JSON utils test suite", () => {
 
@@ -39,5 +39,15 @@ describe("JSON utils test suite", () => {
         let testValue1 = "2011-10-05T14:48:00.000Z";
 
         expect(parseReviver("test", testValue1)).toEqual(new Date(testValue1));
+    });
+
+    it("should pass object in multiple functions", () => {
+       const object = { id: 'test' },
+            transformer = (modifier: string) => (x: any) => {
+           x.id = `${x.id}${modifier}`;
+           return x;
+       };
+
+       expect(pipe(transformer('1'), transformer('2'))(object)).toEqual(jasmine.objectContaining({ id: 'test12' }));
     });
 });

--- a/projects/ng-dynamic-forms/core/src/lib/utils/json.utils.ts
+++ b/projects/ng-dynamic-forms/core/src/lib/utils/json.utils.ts
@@ -40,3 +40,7 @@ export function parseReviver(_key: string, value: any): any {
 
     return isString(value) && regexDateISO.test(value) ? new Date(value) : value;
 }
+
+export function pipe<T = any>(...fns: ((x: T) => T)[]): (x: T) => T {
+    return x => fns.reduce((v, f) => f(v), x);
+}


### PR DESCRIPTION
This feature adds the ability to add an array of model JSON transform functions through an injectionToken.

```typescript
export type ModelJSONTransformFn<T> = (modelJSON: T) => T;

export type DynamicFormControlJSONTransformFnArray<T = any> = ModelJSONTransformFn<T>[];
export const DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY = new InjectionToken<DynamicFormControlJSONTransformFnArray>(
  'DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY'
);
```

usage:
```typescript
export const DynamicFormControlJSONTransformFnArrayProvider: Provider = {
	provide: DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY,
	useValue: [
		/* transform function here */
	]
};

@NgModule({
	...,
	imports: [
		...,
		ReactiveFormsModule,
		DynamicFormsCoreModule
	],
	providers: [
		...,
		DynamicFormControlJSONTransformFnArrayProvider
	]
})
export class AppModule {}
```


Motivation behind this feature:

Imagine that the form config contains all the labels and text as a path to a translation key.
With this feature, I'm able to Inject an array of transform functions, the first translate all the keys and the second one add an asterisk to the label if the model has required validator.

```typescript
export const DynamicFormControlJSONTransformFnArrayProvider: Provider = {
	provide: DYNAMIC_FORM_CONTROL_JSON_TRANSFORM_FN_ARRAY,
	useFactory: translateService => ([
		translateKeys(translateService),
		addRequiredAsteriskToLabel()
	]),
	deps: [TranslateService]
};
```