### PR TITLE
Fixed bug in example JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1226,7 +1226,7 @@ To specify a single JSON form control model just **assign the mandatory** `type`
         "options": [
             {
                 "label": "Option 1",
-                "value": "option-1",
+                "value": "option-1"
             },
             {
                 "label": "Option 2",


### PR DESCRIPTION
The example in the readme file fails due to an extra comma.